### PR TITLE
Fix/column name

### DIFF
--- a/src/Database/QueryBuilder/Builder.php
+++ b/src/Database/QueryBuilder/Builder.php
@@ -139,7 +139,7 @@ class Builder
      */
     public function orderBy(string $column, string $direction = 'asc'): self
     {
-        $this->orders[] = "`$column` $direction";
+        $this->orders[] = "{$this->quoteColumn($column)} $direction";
         return $this;
     }
 
@@ -150,7 +150,7 @@ class Builder
      */
     public function groupBy(string $column): self
     {
-        $this->groupBy = $column;
+        $this->groupBy = $this->quoteColumn($column);
         return $this;
     }
 
@@ -164,7 +164,7 @@ class Builder
     public function having(string $column, string $operator, string $value): self
     {
         $this->queryValue[] = $value;
-        $this->having[] = "`$column` $operator ?";
+        $this->having[] = "{$this->quoteColumn($column)} $operator ?";
         return $this;
     }
 
@@ -183,7 +183,7 @@ class Builder
     public function where(string $column, ComparisonOperator $comparisonOperator, string $value): self
     {
         $this->queryValue[] = $value;
-        $this->wheres[] = "`$column` {$comparisonOperator->value} ?";
+        $this->wheres[] = "{$this->quoteColumn($column)} {$comparisonOperator->value} ?";
         return $this;
     }
 
@@ -203,7 +203,7 @@ class Builder
     {
         if ($this->wheres !== []) {
             $this->queryValue[] = $value;
-            $this->orWheres[] = "`$column` {$comparisonOperator->value} ?";
+            $this->orWheres[] = "{$this->quoteColumn($column)} {$comparisonOperator->value} ?";
         }
         return $this;
     }
@@ -215,7 +215,7 @@ class Builder
      */
     public function whereNull(string $column): self
     {
-        $this->wheres[] = "$column IS NULL";
+        $this->wheres[] = "{$this->quoteColumn($column)} IS NULL";
         return $this;
     }
 
@@ -229,7 +229,7 @@ class Builder
     {
         array_push($this->queryValue, ...$values);
         $valuesPlaceHolder = trim(implode(', ', array_pad([], count($values), '?')));
-        $this->wheres[] = "`$column` IN ($valuesPlaceHolder)";
+        $this->wheres[] = "{$this->quoteColumn($column)} IN ($valuesPlaceHolder)";
         return $this;
     }
 
@@ -243,7 +243,7 @@ class Builder
     {
         array_push($this->queryValue, ...$values);
         $valuesPlaceHolder = trim(implode(', ', array_pad([], count($values), '?')));
-        $this->orWheres[] = "`$column` IN ($valuesPlaceHolder)";
+        $this->orWheres[] = "{$this->quoteColumn($column)} IN ($valuesPlaceHolder)";
         return $this;
     }
 
@@ -261,7 +261,7 @@ class Builder
     {
         array_push($this->queryValue, ...$values);
         $valuesPlaceHolder = trim(implode(', ', array_pad([], count($values), '?')));
-        $this->wheres[] = "`$column` NOT IN ($valuesPlaceHolder)";
+        $this->wheres[] = "{$this->quoteColumn($column)} NOT IN ($valuesPlaceHolder)";
         return $this;
     }
 
@@ -279,7 +279,7 @@ class Builder
     {
         array_push($this->queryValue, ...$values);
         $valuesPlaceHolder = trim(implode(', ', array_pad([], count($values), '?')));
-        $this->orWheres[] = "`$column` NOT IN ($valuesPlaceHolder)";
+        $this->orWheres[] = "{$this->quoteColumn($column)} NOT IN ($valuesPlaceHolder)";
         return $this;
     }
 
@@ -290,7 +290,7 @@ class Builder
      */
     public function whereNotNull(string $column): self
     {
-        $this->wheres[] = "$column IS NOT NULL";
+        $this->wheres[] = "{$this->quoteColumn($column)} IS NOT NULL";
         return $this;
     }
 
@@ -409,6 +409,7 @@ class Builder
      */
     private function select(array $columns = ['*']): self
     {
+        $columns = array_map(fn ($item): string => $this->quoteColumn($item), $columns);
         $this->selectColumns = implode(', ', $columns);
         return $this;
     }

--- a/src/Traits/QueryComponents.php
+++ b/src/Traits/QueryComponents.php
@@ -144,4 +144,33 @@ trait QueryComponents
     {
         return trim(implode(', ', array_pad([], count($insertColumns), '?')));
     }
+
+    /**
+     * Checks if the given column name contains a reserved SQL keyword
+     * that requires backticks for proper quoting.
+     *
+     * @param string $column The column name (or a dot-separated path to a nested column).
+     *
+     * @return bool Returns true if the column name contains a reserved keyword that requires backticks; false otherwise.
+     */
+    private function needsBacktick(string $column): bool
+    {
+        $reservedKeywords = ["order", "group", "select", "from", "where", "limit", "offset", "join", "inner", "outer", "left", "right", "on", "desc", "asc"];
+        $columnParts = explode('.', $column);
+        return array_intersect($reservedKeywords, $columnParts) !== [];
+    }
+
+    /**
+     * Quotes the column name if needed by surrounding reserved SQL keywords
+     * with backticks.
+     *
+     * @param string $column The column name (or a dot-separated path to a nested column) to be quoted.
+     *
+     * @return string The quoted column name with backticks around any reserved SQL keywords, or the column name unmodified if no backticks are needed.
+     */
+    public function quoteColumn(string $column): string
+    {
+        $needsBacktick = $this->needsBacktick($column);
+        return implode('.', array_map(fn ($item): string => $needsBacktick ? "`$item`" : $item, explode('.', $column)));
+    }
 }

--- a/tests/QueryBuilder/QueryComponentsTest.php
+++ b/tests/QueryBuilder/QueryComponentsTest.php
@@ -54,4 +54,16 @@ final class QueryComponentsTest extends TestCase
     {
         $this->assertEquals("?, ?, ?", $this->buildInsertPlaceholder(["name", "email", "password"]));
     }
+
+    public function test_needs_backtick(): void
+    {
+        $this->assertEquals(true, $this->needsBacktick("order.customerNumber"));
+        $this->assertEquals(false, $this->needsBacktick("customers.CustomerNumber"));
+    }
+
+    public function tests_quote_column(): void
+    {
+        $this->assertEquals("`order`.`customerNumber`", $this->quoteColumn("order.customerNumber"));
+        $this->assertEquals("customers.CustomerNumber", $this->quoteColumn("customers.CustomerNumber"));
+    }
 }


### PR DESCRIPTION
Fix column name reserved names in mysql.
eg. Changes ```order.column_name``` to ``` `order`.`column_name` ```.